### PR TITLE
update DataSourceData and ResourceData to client instance

### DIFF
--- a/internal/provider/instance_data_source.go
+++ b/internal/provider/instance_data_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	ukc "sdk.kraft.cloud"
 	"sdk.kraft.cloud/instances"
 )
 
@@ -156,16 +157,16 @@ func (d *InstanceDataSource) Configure(ctx context.Context, req datasource.Confi
 		return
 	}
 
-	client, ok := req.ProviderData.(instances.InstancesService)
+	client, ok := req.ProviderData.(ukc.KraftCloud)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected instances.InstancesServices, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected KraftCloud, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	d.client = client
+	d.client = client.Instances()
 }
 
 // Read implements datasource.DataSource.

--- a/internal/provider/instance_resource.go
+++ b/internal/provider/instance_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	ukc "sdk.kraft.cloud"
 	"sdk.kraft.cloud/instances"
 	"sdk.kraft.cloud/services"
 )
@@ -240,16 +241,16 @@ func (r *InstanceResource) Configure(ctx context.Context, req resource.Configure
 		return
 	}
 
-	client, ok := req.ProviderData.(instances.InstancesService)
+	client, ok := req.ProviderData.(ukc.KraftCloud)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Resource Configure Type",
-			fmt.Sprintf("Expected instances.InstancesServices, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected KraftCloud, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	r.client = client
+	r.client = client.Instances()
 }
 
 // Create implements resource.Resource.

--- a/internal/provider/instances_data_source.go
+++ b/internal/provider/instances_data_source.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	ukc "sdk.kraft.cloud"
 	"sdk.kraft.cloud/instances"
 )
 
@@ -82,16 +83,16 @@ func (d *InstancesDataSource) Configure(ctx context.Context, req datasource.Conf
 		return
 	}
 
-	client, ok := req.ProviderData.(instances.InstancesService)
+	client, ok := req.ProviderData.(ukc.KraftCloud)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected instances.InstancesServices, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected KraftCloud, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}
 
-	d.client = client
+	d.client = client.Instances()
 }
 
 // Read implements datasource.DataSource.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	unikraftcloud "sdk.kraft.cloud"
+	ukc "sdk.kraft.cloud"
 	"sdk.kraft.cloud/client"
 )
 
@@ -146,13 +146,13 @@ func (p *UnikraftCloudProvider) Configure(ctx context.Context, req provider.Conf
 	}
 
 	// Client configuration for data sources and resources
-	client := unikraftcloud.NewClient(
-		unikraftcloud.WithDefaultMetro(metro),
-		unikraftcloud.WithToken(token),
+	client := ukc.NewClient(
+		ukc.WithDefaultMetro(metro),
+		ukc.WithToken(token),
 	)
 
-	resp.DataSourceData = client.Instances()
-	resp.ResourceData = client.Instances()
+	resp.DataSourceData = client
+	resp.ResourceData = client
 }
 
 // Resources describes the provider data model.


### PR DESCRIPTION
This PR is preparation for a set of following PRs to include more Unikraft resource types in the provider. This modifies the `DataSourceData` and `ResourceData` objects to contain the `KraftCloud` client instance instead of the `InstancesService`. Additional resource types will then be able to access their respective services similar to the existing instances provider.